### PR TITLE
Fixed search engine specification in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ The API(s) provided by query-server are as follows:
 
 ` GET /api/v1/search/<search-engine>/query=query&format=format `
 
-> <search-engine> : ['google' , 'bing', 'duckduckgo' , 'yahoo']
-> query : query can be any string
-> format : [ `json`, `xml` ]
+> *search-engine* : ['google' , 'bing', 'duckduckgo' , 'yahoo']
+
+> *query* : query can be any string 
+
+> *format* : [ `json`, `xml` ]
 
 A sample query : `/api/v1/search/bing/query=fossasia&format=xml`
 


### PR DESCRIPTION
Current:
> <search-engine> : ['google' , 'bing', 'duckduckgo' , 'yahoo']
> query : query can be any string
> format : [ `json`, `xml` ]

Proposed change:
> *search-engine* : ['google' , 'bing', 'duckduckgo' , 'yahoo']

> *query* : query can be any string 

> *format* : [ `json`, `xml` ]