### PR TITLE
Limit support Python 2.7, Add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A sample query : `/api/v1/search/bing?query=fossasia&format=xml`
     * [dicttoxml](https://github.com/quandyfactory/dicttoxml)
     * [Flask](http://flask.pocoo.org)
     * [pymongo](https://api.mongodb.com/python/current)
-    * [requests.org](http://docs.python-requests.org)
+    * [requests](http://docs.python-requests.org)
 * [Node.js](https://nodejs.org/en)
     * [bower.io](https://bower.io)
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ A sample query : `/api/v1/search/bing?query=fossasia&format=xml`
 
 ## Dependencies
 
-* Python 2.x or Python 3.x
-* [Node.js](https://nodejs.org/en/)
-* [Pip](https://pip.pypa.io/en/stable/installing/)
-* [Flask](http://flask.pocoo.org/)
-* [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
+* Python 2.7
+    * [Pip](https://pip.pypa.io/en/stable/installing)
+    * [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc)
+    * [dicttoxml](https://github.com/quandyfactory/dicttoxml)
+    * [Flask](http://flask.pocoo.org)
+    * [pymongo](https://api.mongodb.com/python/current)
+    * [requests.org](http://docs.python-requests.org)
+* [Node.js](https://nodejs.org/en)
+    * [bower.io](https://bower.io)
 
 
 ## Installation


### PR DESCRIPTION
* #123 and #125 demonstrate that the claim of Python 3 compatibility is not yet warranted.
    * Python 2.6 and earlier are already [EOL](https://docs.python.org/devguide/index.html#branchstatus).
* #126 demonstrates that there are missing dependencies