### PR TITLE
Major changes on DuckDuckGo scraping technique

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -52,26 +52,37 @@ def get_duckduckgo_page(query):
     """
     header = {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.116 Safari/537.36'}
-    payload = {'q': query}
-    response = requests.get('https://duckduckgo.com/html', headers=header, params=payload)
+    response = requests.get('https://duckduckgo.com/html' + query, headers=header)
     return response
 
 
-def duckduckgo_search(query):
-    """ Search google for the query and return set of urls
+def duckduckgo_search(query, count):
+    """ Search duckduckgo for the query and return set of urls
     Returns: urls (list)
             [[Tile1,url1], [Title2, url2],..]
     """
     urls = []
-    response = get_duckduckgo_page(query)
-    soup = BeautifulSoup(response.text, 'html.parser')
-    for links in soup.findAll('a', {'class': 'result__a'}):
-        desc = links.find_next('a')
-        urls.append({'title': links.getText(),
-                     'link': links.get('href'),
-                     'desc': desc.getText()})
+    query = '/?q=' + query
+    while True:
+        response = get_duckduckgo_page(query)
+        soup = BeautifulSoup(response.text, 'html.parser')
+        navLink = soup.find_all('div', {'class': 'nav-link'})
+        if navLink:
+            navLinkForm = navLink[-1].find('form', {'action': '/html/', 'method': 'post'})
+            navLinkForm = navLinkForm.find_all('input')
+            parameters = [(i['name']+'='+i['value']) for i in navLinkForm[1:]]
+            parameters = '&'.join(parameters)
 
-    return urls
+            for links in soup.findAll('a', {'class': 'result__a'}):
+                desc = links.find_next('a')
+                urls.append({'title': links.getText(),
+                             'link': links.get('href'),
+                             'desc': desc.getText()})
+                if(len(urls) == count):
+                    return urls
+            query = '/?' + parameters
+        else:
+            return urls
 
 
 def get_google_page(query,index):
@@ -160,7 +171,7 @@ def feedgen(query, engine,count):
     if engine == 'g':
         urls = google_search(query,count)
     elif engine == 'd':
-        urls = duckduckgo_search(query)
+        urls = duckduckgo_search(query, count)
     elif engine == 'y':
         urls = yahoo_search(query,count)
     else:

--- a/app/server.py
+++ b/app/server.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, request, url_for, abort, Response, make_response
-from scrapers import feedgen
+from scraper import feedgen
 from pymongo import MongoClient
 from dicttoxml import dicttoxml
 from xml.dom.minidom import parseString
@@ -28,7 +28,7 @@ def bad_request(err):
 def search(search_engine):
     try:
         if request.method == 'GET':
-            num = request.args.get('num')
+            num = request.args.get('num') or 10
             count = int(num)
             qformat = request.args.get('format') or 'json'
             if qformat not in ['json', 'xml']:

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,7 +22,7 @@
 <body style="position: relative; margin: 0; padding-bottom: 6rem; min-height: 100%; font-family:Droid Sans Mono">
 <a href="https://github.com/fossasia/query-server.git">
     <img style="position:absolute; top:0; right:0; border:0;" src="{{ url_for('static', filename='images/forkme_right_green_007200.png') }}"
-         alt="Fork me on GitHub" title="loklak server source code on github">
+         alt="Fork me on GitHub" title="query-server source code on github">
 </a>
 <div class="jumbotron">
     <div class="container">


### PR DESCRIPTION
Fixes: #154 

Additional Fix:
1. For duckduckgo it was scraping only 30 queries for rest it was giving error. So i extended till 100+
2. If num parameter is not passed then it gives type-error so I changed it to default 10
3. HTML Typo fixed

For duckduckgo scraping it first extract the data with simple query and then it fetch one form and extract all the parameters and then again make one request with those parameters. For max it can scrape 170 -190  per call because in browsing experience too you can see this much result only.

Image shows result if we pass num=50 in case of duckduckgo search
![screenshot from 2017-09-19 23-11-43](https://user-images.githubusercontent.com/9320644/30606632-f12044d4-9d8f-11e7-9058-2d823785699a.png)
