### PR TITLE
Add Python 3 to testing to align with README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,5 @@ before_script:
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - echo success
-# - py.test app/rss-generator.py
-# - py.test --cov
 after_success:
   - coveralls 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 language: python
 python:
- - "2.7"
-install: 
- - pip install -r requirements.txt
+  - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
+install:
+  - pip install flake8
+  - pip install -r requirements.txt
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - echo success
-#  - py.test app/rss-generator.py
-#  - py.test --cov
-after_success: 
- - coveralls 
+# - py.test app/rss-generator.py
+# - py.test --cov
+after_success:
+  - coveralls 


### PR DESCRIPTION
README.md says we support Python 3 but we are not testing on Python 3.
* Travis CI will now do parallel test runs on both Python 2 and Python 3.
* The tests must pass on Python 2.7 for the build to succeed.
* All Python 3.6 issues are _temporarily_ treated only as warnings.

Output: https://travis-ci.org/fossasia/query-server/builds/278998946