### PR TITLE
Remove allow_failures on Travis CI Python 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.6"
-matrix:
-  allow_failures:
-    - python: "3.6"
 install:
   - pip install flake8
   - pip install -r requirements.txt


### PR DESCRIPTION
With #197 merged, the Python 3 crucial tests now pass in Travis CI so let's lock that criteria into all future PRs.