### PR TITLE
Remove flake8 cruft from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ install:
   - pip install flake8
   - pip install -r requirements.txt
 before_script:
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --max-complexity=11 --max-line-length=85 --statistics
+  - flake8 . --count --max-complexity=11 --max-line-length=85 --show-source --statistics
 script:
   - echo success
 after_success:


### PR DESCRIPTION
Now that we run flake8 in zero tolerance mode, we can run a single pass instead of two passes.