### PR TITLE
Scrapers implement absolute_import for Python 3

### DIFF
--- a/app/scrapers/ask.py
+++ b/app/scrapers/ask.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
+from .generalized import Scraper
 
 
 class Ask(Scraper):

--- a/app/scrapers/baidu.py
+++ b/app/scrapers/baidu.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
+from .generalized import Scraper
 
 
 class Baidu(Scraper):
@@ -22,6 +24,6 @@ class Baidu(Scraper):
             url = h3.a.get('href')
             urls.append({'title': title, 'link': url})
 
-        print('parsed' + str(urls))
+        print('Baidu parsed: ' + str(urls))
 
         return urls

--- a/app/scrapers/bing.py
+++ b/app/scrapers/bing.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
+from .generalized import Scraper
 
 
 class Bing(Scraper):
@@ -25,6 +27,6 @@ class Bing(Scraper):
                          'desc': desc}
             urls.append(url_entry)
 
-        print('parsed' + str(urls))
+        print('Bing parsed: ' + str(urls))
 
         return urls

--- a/app/scrapers/duckduckgo.py
+++ b/app/scrapers/duckduckgo.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
+from .generalized import Scraper
 
 
 class Duckduckgo(Scraper):
@@ -20,6 +22,6 @@ class Duckduckgo(Scraper):
             urls.append({'title': links.getText(),
                          'link': links.get('href')})
 
-        print('parsed' + str(urls))
+        print('Duckduckgo parsed: ' + str(urls))
 
         return urls

--- a/app/scrapers/google.py
+++ b/app/scrapers/google.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
+from .generalized import Scraper
 
 
 class Google(Scraper):
@@ -23,6 +25,6 @@ class Google(Scraper):
             links = h3.find('a')
             urls.append({'title': links.getText(), 'link': links.get('href')})
 
-        print('parsed' + str(urls))
+        print('Google parsed: ' + str(urls))
 
         return urls

--- a/app/scrapers/yahoo.py
+++ b/app/scrapers/yahoo.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+
 import urllib
+
+from .generalized import Scraper
 
 
 class Yahoo(Scraper):
@@ -30,6 +33,6 @@ class Yahoo(Scraper):
                     'link': u
                 })
 
-        print('parsed' + str(urls))
+        print('Yahoo parsed: ' + str(urls))
 
         return urls

--- a/app/scrapers/yandex.py
+++ b/app/scrapers/yandex.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 from __future__ import print_function
-from generalized import Scraper
+from .generalized import Scraper
 
 
 class Yandex(Scraper):
@@ -18,6 +19,6 @@ class Yandex(Scraper):
         for a in soup.findAll('a', {'class': 'link link_theme_normal'}):
             urls.append({'title': a.getText(), 'link': a.get('href')})
 
-        print('parsed' + str(urls))
+        print('Yandex parsed: ' + str(urls))
 
         return urls


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Partial fix for #226
This should help the codebase to achieve Python 3 compatibility.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [X] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
- Adds `from __future__ import absolute_import` and .imports within a module
- Used isort to sort imports
- Added scraper name to print() as discussed at https://github.com/fossasia/query-server/pull/240#discussion_r147052228
