### PR TITLE
Make pytest pass both locally and in Travis CI

### DIFF
--- a/app/test_server.py
+++ b/app/test_server.py
@@ -7,33 +7,37 @@ from .scrapers import small_test
 def test_small_test():
     small_test()
 """
+
+import os
 import sys
+
 import pytest
 import requests
+
+
+PYTHON3 = sys.version_info.major >= 3
+REASON = 'Python 3 blocked until #297 goes live'
+TRAVIS_CI = os.getenv('TRAVIS', False)  # Running in Travis CI?
 
 
 def test_true():
     assert True, "We have a problem!"
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 0),
-                   reason='Python 3 blocked until #297 goes live')
+@pytest.mark.xfail(PYTHON3 or not TRAVIS_CI, reason=REASON)
 def test_invalid_url_api_call():
     response = requests.get('http://localhost:7001/api/v1/search/invalid_url')
     assert response.json()['Status Code'] == 404
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 0),
-                   reason='Python 3 blocked until #297 goes live')
 def make_engine_api_call(engine_name):
     url = 'http://localhost:7001/api/v1/search/' + engine_name
     assert requests.get(url).json()['Status Code'] == 400, engine_name
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 0),
-                   reason='Python 3 blocked until #297 goes live')
+@pytest.mark.xfail(PYTHON3 or not TRAVIS_CI, reason=REASON)
 def test_engine_api_calls(engine_names=None):
     engines = ['ask', 'ubaidu', 'bing', 'duckduckgo', 'tyoutube',
-               'exalead', 'google', 'quora', 'yahoo', 'yandex']
+               'exalead', 'mojeek', 'google', 'quora', 'yahoo', 'yandex']
     for engine_name in (engine_names or engines):
         make_engine_api_call(engine_name)


### PR DESCRIPTION
@shaddygarg Your review of these changes please.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Add a few constants to make the tests easier to understand
- Expect to external url test to fail if we are not running in Travis CI
- Add mojeek to the testing

* If you are running the query-server locally, you will still be able to see that the tests pass.
* If you are not running the query-server locally, the rest of the tests will still run.
* If you are in Travis CI all tests will run as expected (or the build will fail).
