### PR TITLE
Fix syntax which activates venv

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -23,7 +23,7 @@ npm install -g bower
 bower install
 pip install virtualenv
 virtualenv venv
-source activate venv # Linux
+. venv/bin/activate # Linux
 venv\Scripts\activate # Windows
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Fixes #366 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- The previous syntax was `source activate venv` which was not working is updated to new syntax `. venv/bin/activate` works well in this case. This syntax is equivalent to `source venv/bin/activate`.
