### PR TITLE
Lookup scrapers by name, not by initial w/ backward compatibility

### DIFF
--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -1,48 +1,48 @@
 from __future__ import print_function
-import json
-import sys
-from google import Google
-from duckduckgo import Duckduckgo
-from bing import Bing
-from yahoo import Yahoo
+
 from ask import Ask
-from yandex import Yandex
 from baidu import Baidu
-from exalead import Exalead
-from quora import Quora
-from youtube import Youtube
-from parsijoo import Parsijoo
-from mojeek import Mojeek
+from bing import Bing
 from dailymotion import Dailymotion
+from duckduckgo import Duckduckgo
+from exalead import Exalead
+from google import Google
+from mojeek import Mojeek
+from parsijoo import Parsijoo
+from quora import Quora
+from yahoo import Yahoo
+from yandex import Yandex
+from youtube import Youtube
 
 scrapers = {
-    'g': Google(),
-    'b': Bing(),
-    'y': Yahoo(),
-    'd': Duckduckgo(),
-    'a': Ask(),
-    'yd': Yandex(),
-    'u': Baidu(),
-    'e': Exalead(),
-    'q': Quora(),
-    't': Youtube(),
-    'p': Parsijoo(),
-    'm': Mojeek(),
-    'v': Dailymotion()
+    'ask': Ask(),
+    'baidu': Baidu(),
+    'bing': Bing(),
+    'dailymotion': Dailymotion(),
+    'duckduckgo': Duckduckgo(),
+    'exalead': Exalead(),
+    'google': Google(),
+    'mojeek': Mojeek(),
+    'parsijoo': Parsijoo(),
+    'quora': Quora(),
+    'yahoo': Yahoo(),
+    'yandex': Yandex(),
+    'youtube': Youtube()
 }
 
 
-def read_in():
-    lines = sys.stdin.readlines()
-    return json.loads(lines[0])
-
-
 def small_test():
-    assert isinstance(scrapers.google.results_search('fossasia'), list)
+    assert isinstance(scrapers['google'].search('fossasia'), list)
 
 
 def feedgen(query, engine, count=10):
-    if engine in ['q', 't']:
+    engine = engine.lower()
+    # provide temporary backwards compatibility for old names
+    old_names = {'ubaidu': 'baidu',
+                 'vdailymotion': 'dailymotion',
+                 'tyoutube': 'youtube'}
+    engine = old_names.get(engine, engine)
+    if engine in ('quora', 'youtube'):
         urls = scrapers[engine].search_without_count(query)
     else:
         urls = scrapers[engine].search(query, count)

--- a/app/server.py
+++ b/app/server.py
@@ -57,7 +57,7 @@ def search(search_engine):
             err = [400, 'Not Found - missing query', qformat]
             return bad_request(err)
 
-        result = feedgen(query, engine[0], count)
+        result = feedgen(query, engine, count)
         if not result:
             err = [404, 'No response', qformat]
             return bad_request(err)


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #271 and #273
Replaces #235, #307, #327

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [X] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- #230 (comment) Lookup scrapers by name instead of by a single letter.
- Provide backward compatibility so we do not need to change susi, etc.
- Remove the unused read_in()

Codacy failure is caused by #332