### PR TITLE
Use parenthesize to avoid backslashs for line continuation

### DIFF
--- a/test/test_quora.py
+++ b/test/test_quora.py
@@ -4,9 +4,9 @@ from app.scrapers import Quora
 
 
 def test_parse_response():
-    html_text = "<div><a class='question_link' href='/mock_url'>" \
-        "<span class='question_text'><span class='rendered_qtext'>" \
-        "mock_title</span></span></a></div>"
+    html_text = ("<div><a class='question_link' href='/mock_url'>"
+                 "<span class='question_text'><span class='rendered_qtext'>"
+                 "mock_title</span></span></a></div>")
     dummy_soup = BeautifulSoup(html_text, 'html.parser')
     expected_resp = [{
         'title': u'mock_title',

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -124,9 +124,9 @@ def expected_response_for_format(qformat):
     elif qformat == 'csv':
         return '"link","title","desc"\n"mock_link","mock_title","mock_desc"'
     elif qformat == 'xml':
-        return '<?xml version="1.0" ?><channel><item>' \
-               '<desc>mock_desc</desc><link>mock_link</link>' \
-               '<title>mock_title</title></item></channel>'
+        return ('<?xml version="1.0" ?><channel><item>'
+                '<desc>mock_desc</desc><link>mock_link</link>'
+                '<title>mock_title</title></item></channel>')
 
 
 def get_json_equivalent_from_csv_feed(feed):

--- a/test/test_yahoo.py
+++ b/test/test_yahoo.py
@@ -4,9 +4,9 @@ from app.scrapers import Yahoo
 
 
 def test_parse_response():
-    html_text = '<h3 class="title"><a class=" ac-algo fz-l ac-21th lh-24"' \
-        ' href="//r.search.yahoo.com/_ylt=Awr;_ylu=X3--/RV=2/RE=15/RO=10' \
-        '/RU=mock_url/RK=2/RS=Gne">mock_title</a></h3> '
+    html_text = ('<h3 class="title"><a class=" ac-algo fz-l ac-21th lh-24" '
+                 'href="//r.search.yahoo.com/_ylt=Awr;_ylu=X3--/RV=2/RE=15/'
+                 'RO=10/RU=mock_url/RK=2/RS=Gne">mock_title</a></h3> ')
     dummy_soup = BeautifulSoup(html_text, 'html.parser')
     expected_resp = [{
         'title': u'mock_title',

--- a/test/test_youtube.py
+++ b/test/test_youtube.py
@@ -4,11 +4,11 @@ from app.scrapers import Youtube
 
 
 def test_parse_response():
-    html_text = '<a href="/channel/UCQprMsG-raCIMlBudm20iLQ" ' \
-        'class="yt-uix-sessionlink">mock_channel</a><a href=' \
-        '"/watch?v=mock" class="yt-uix-tile-link yt-ui-ellipsis ' \
-        'yt-ui-ellipsis-2 yt-uix-sessionlink" ' \
-        'title="mock_title">mock_title</a>'
+    html_text = ('<a href="/channel/UCQprMsG-raCIMlBudm20iLQ" '
+                 'class="yt-uix-sessionlink">mock_channel</a><a href='
+                 '"/watch?v=mock" class="yt-uix-tile-link yt-ui-ellipsis '
+                 'yt-ui-ellipsis-2 yt-uix-sessionlink" '
+                 'title="mock_title">mock_title</a>')
     dummy_soup = BeautifulSoup(html_text, 'html.parser')
     expected_resp = [{
         'title': u'mock_title',


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes PEP8 compatibility  https://www.python.org/dev/peps/pep-0008/#maximum-line-length

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [X] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
- Use parenthesize instead of backslash for line continuation for PEP8 compatibility 

Rational: If someone puts a space character to the right of the backslash, the program breaks but the change is not visible to the reader.
