### PR TITLE
Fix margin of Engine label and dropdown

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -66,7 +66,7 @@
                     <br/>
 
                     <div class="row">
-                        <div class="col-sm-3 col-xs-6" style="padding:0; margin: 0 auto;">
+                        <div class="col-sm-3 col-xs-6" style="padding:0; margin-right:30px; margin-left:16px; margin-bottom: 10px;">
                             <div class="dropdown">
                                 <label>Engine:</label><br/>
                                 <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">
@@ -93,19 +93,20 @@
                                 </ul>
                             </div>
                         </div>
-                        <div class="col-sm-5 col-xs-6">
+                        <div class="col-sm-3 col-xs-6" style="padding:0; max-width:100%; margin-left:16px; margin-right:30px;">
                                 <label>Type:</label><br/>
-                                <div id="type" class="btn-group btn-group-vertical" style="display:inline-flex;padding:0; margin: 0 auto;" data-toggle="buttons">
-                                    <label class=" active typeButton" style="padding:10px;">General<br/>
+                                <div id="type" class="btn-group btn-group-vertical" style="display:inline-flex;" data-toggle="buttons">
+                                    <label class=" active typeButton" style="padding: 0px 10px 10px;">General<br/>
                                             <input type="radio" name = "stype" value="" autocomplete="off" checked>
                                     </label>
-                                    <label class=" typeButton" style="padding:10px;">Images<br/>
+                                    <label class=" typeButton" style="padding: 0px 10px 10px;">Images<br/>
                                             <input type="radio" name = "stype" value="isch" autocomplete="off">
                                     </label>
-                                    <label class=" typeButton" style="padding:10px;">Video<br/>
+                                    <label class=" typeButton" style="padding: 0px 10px 10px;">
+                                        Video<br/>
                                             <input type="radio" name = "stype" value="vid" autocomplete="off">
                                     </label>
-                                    <label class=" typeButton" style="padding:10px;">News<br/>
+                                    <label class=" typeButton" style="padding: 0px 10px 10px;">News<br/>
                                             <input type="radio" name = "stype" value="news" autocomplete="off">
                                     </label>
                                 </div>


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #483 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Margin set for correct indent in mobile device too.
- Try this on mobile device: https://cryptic-hamlet-20959.herokuapp.com/
- Original link: https://query-server.herokuapp.com/

![img-20180129-wa0002](https://user-images.githubusercontent.com/20624380/35518376-6568baf6-0537-11e8-8eb5-418f91adac64.jpg)

