### PR TITLE
Eliminate the search_without_count function

### DIFF
--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -42,8 +42,6 @@ def feed_gen(query, engine, count=10, qtype=''):
                  'vdailymotion': 'dailymotion',
                  'tyoutube': 'youtube'}
     engine = old_names.get(engine, engine)
-    if engine in ('quora', 'youtube'):
-        urls = scrapers[engine].search_without_count(query)
-    else:
-        urls = scrapers[engine].search(query, count, qtype)
+    urls = scrapers[engine].search(query, count, qtype)
+
     return urls

--- a/test/test_ask.py
+++ b/test/test_ask.py
@@ -74,3 +74,24 @@ def test_parse_video_response():
         }
     ]
     assert resp == expected_resp
+
+
+def test_search_ask_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Ask().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_ask_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Ask().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_ask_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Ask().search(query, 27))
+    assert resp_count == expected_max_resp_count

--- a/test/test_baidu.py
+++ b/test/test_baidu.py
@@ -16,6 +16,27 @@ def test_parse_response():
     assert resp == expected_resp
 
 
+def test_search_baidu_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Baidu().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_baidu_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Baidu().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_baidu_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Baidu().search(query, 27))
+    assert resp_count == expected_max_resp_count
+
+
 def test_parse_news_response():
     html_text = """<h3 class="c-title">
         <a href="mock_url" target="_blank">mock_title</a>

--- a/test/test_bing.py
+++ b/test/test_bing.py
@@ -42,6 +42,27 @@ def test_parse_video_response():
     assert resp == expected_resp
 
 
+def test_search_bing_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Bing().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_bing_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Bing().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_bing_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Bing().search(query, 27))
+    assert resp_count == expected_max_resp_count
+
+
 def test_parse_news_response():
     html_text = """<div class="t_s"><div class="t_t"><a class="title"
         href="mock_url">mock_title</a></div><div class="snippet">

--- a/test/test_duckduckgo.py
+++ b/test/test_duckduckgo.py
@@ -14,3 +14,24 @@ def test_parse_response():
         'link': u'mock_url'
     }]
     assert resp == expected_resp
+
+
+def test_search_duckduckgo_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(DuckDuckGo().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_duckduckgo_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(DuckDuckGo().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_duckduckgo_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(DuckDuckGo().search(query, 27))
+    assert resp_count == expected_max_resp_count

--- a/test/test_generalized.py
+++ b/test/test_generalized.py
@@ -61,28 +61,3 @@ def test_search_parsed_response_none(mock_resp, mock_get):
                return_value=None):
         resp = Scraper().search('dummy_query', 1)
         assert resp == []
-
-
-@patch('app.scrapers.generalized.requests.get')
-@patch('app.scrapers.generalized.Scraper.parse_response')
-@patch('requests.models.Response')
-def test_search_without_count(mock_resp, mock_parse_resp, mock_get):
-    mock_get.return_value = mock_resp
-    mock_resp.text = 'mock response'
-    expected_resp = [{
-        'title': 'mock_title',
-        'link': 'mock_url'
-    }]
-    expected_payload = {'q': 'dummy_query'}
-    expected_headers = {
-        'User-Agent': (
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) '
-            'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.116 '
-            'Safari/537.36'
-        )
-    }
-    mock_parse_resp.return_value = expected_resp
-    resp = Scraper().search_without_count('dummy_query')
-    assert resp == expected_resp
-    mock_get.assert_called_with(
-        '', headers=expected_headers, params=expected_payload)

--- a/test/test_google.py
+++ b/test/test_google.py
@@ -14,3 +14,24 @@ def test_parse_response():
     }]
     resp = Google().parse_response(dummy_soup)
     assert resp == expected_resp
+
+
+def test_search_google_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Google().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_google_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Google().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_google_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Google().search(query, 27))
+    assert resp_count == expected_max_resp_count

--- a/test/test_mojeek.py
+++ b/test/test_mojeek.py
@@ -14,6 +14,27 @@ def test_parse_response():
     assert resp == expected_resp
 
 
+def test_search_mojeek_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Mojeek().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_mojeek_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Mojeek().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_mojeek_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Mojeek().search(query, 27))
+    assert resp_count == expected_max_resp_count
+
+
 def test_parse_news_response():
     html_text = '<a href="mock_url" class="ob">mock_title</a>'
     dummy_soup = BeautifulSoup(html_text, 'html.parser')

--- a/test/test_parsijoo.py
+++ b/test/test_parsijoo.py
@@ -22,6 +22,27 @@ def test_parse_response():
     assert resp == expected_resp
 
 
+def test_search_parsijoo_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Parsijoo().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_parsijoo_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Parsijoo().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_parsijoo_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Parsijoo().search(query, 27))
+    assert resp_count == expected_max_resp_count
+
+
 def test_parse_video_response():
     html_text = """<a href="mock_url" class="over-page"
     title="mock_title">mock_title</a>"""

--- a/test/test_quora.py
+++ b/test/test_quora.py
@@ -14,3 +14,30 @@ def test_parse_response():
     }]
     resp = Quora().parse_response(dummy_soup)
     assert resp == expected_resp
+
+
+# Quora search for "fossasia" returns 9 results
+def test_search_quora_without_count():
+    query = 'fossasia'
+    actual_resp_count = 9
+    expected_max_resp_count = 10
+    resp_count = len(Quora().search(query))
+    assert (resp_count == actual_resp_count) and \
+           (resp_count <= expected_max_resp_count)
+
+
+def test_search_quora_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Quora().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+# Quora search for "fossasia" returns 9 results
+def test_search_quora_with_large_count():
+    query = 'fossasia'
+    actual_resp_count = 9
+    expected_max_resp_count = 27
+    resp_count = len(Quora().search(query, 27))
+    assert (resp_count == actual_resp_count) and \
+           (resp_count <= expected_max_resp_count)

--- a/test/test_yahoo.py
+++ b/test/test_yahoo.py
@@ -16,6 +16,27 @@ def test_parse_response():
     assert resp == expected_resp
 
 
+def test_search_yahoo_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Yahoo().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_yahoo_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Yahoo().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+def test_search_yahoo_with_large_count():
+    query = 'fossasia'
+    expected_max_resp_count = 27
+    resp_count = len(Yahoo().search(query, 27))
+    assert resp_count == expected_max_resp_count
+
+
 def test_parse_image_response():
     html_text = """<li class="ld"><a aria-label="mock_title">
                 <img data-src='mock_url' class='process'/></a></div>"""

--- a/test/test_youtube.py
+++ b/test/test_youtube.py
@@ -16,3 +16,27 @@ def test_parse_response():
     }]
     resp = Youtube().parse_response(dummy_soup)
     assert resp == expected_resp
+
+
+def test_search_youtube_without_count():
+    query = 'fossasia'
+    expected_max_resp_count = 10
+    resp_count = len(Youtube().search(query))
+    assert resp_count == expected_max_resp_count
+
+
+def test_search_youtube_with_small_count():
+    query = 'fossasia'
+    expected_resp_count = 2
+    resp_count = len(Youtube().search(query, 2))
+    assert resp_count == expected_resp_count
+
+
+# Youtube search for "fossasia" returns 23 results
+def test_search_youtube_with_large_count():
+    query = 'fossasia'
+    actual_resp_count = 23
+    expected_max_resp_count = 27
+    resp_count = len(Youtube().search(query, 27))
+    assert (resp_count == actual_resp_count) and \
+           (resp_count <= expected_max_resp_count)


### PR DESCRIPTION
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

The functionality of the search_without_count method has been
implemented within the search method and 3 tests have been added for
each scraper with a common search query "fossasia". The tests are:

 - Without any count
 - With a small count
 - With a large count

Resolves #461