### PR TITLE
URL Encoding for Twitter to use Loklak for Hashtags

### DIFF
--- a/app/scrapers/twitter.py
+++ b/app/scrapers/twitter.py
@@ -15,7 +15,8 @@ class Twitter(Scraper):
         Returns: urls (list)
                 [[Title1,url1], [Title2, url2],..]
         """
-        url = self.loklakURL+query
+        encodedQuery = requests.utils.quote(query, safe='')
+        url = self.loklakURL+encodedQuery
 
         responses = requests.get(url).json()
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -229,7 +229,7 @@
                     $('#load').show();
                     $('#feed').hide();
                     var sengine = $("#engine").val();
-                    var squery = $('#query').val();
+                    var squery = encodeURIComponent($('#query').val());
                     var stype = $("input[name=stype]:checked").val()
                     var sformat = $(' #format label.active input').val();
                     var count = $('#resp').val();


### PR DESCRIPTION
Issue : #517

#### Changes proposed in this pull request
- using `requests.utils.quote()`, add URL Encoder in for Loklak's Twitter API
- Added Encoder in html for Hashtag Search through Webpage
